### PR TITLE
Allow OTA for the ESPHome ITHO plugin

### DIFF
--- a/itho.h
+++ b/itho.h
@@ -39,6 +39,9 @@ String Mydeviceid = "ESPHOME"; // should be changed in boot call,to set user spe
 long LastPublish=0; 
 bool InitRunned = false;
 
+// Variable to check if we have disabled ITHO, to allow OTA
+bool EnableItho = false;
+
 // Timer values for hardware timer in Fan
 #define Time1      10*60
 #define Time2      20*60

--- a/itho.yaml
+++ b/itho.yaml
@@ -112,7 +112,7 @@ switch:
         ESP_LOGI("custom", "Disabled ITHO, to allow OTA (otherwise 'Ticker' library will fail OTA)");
   turn_off_action:
     - lambda: |-
-        EnableItho = true;
+        EnableItho = false;
         attachInterrupt(D1, ITHOinterrupt, RISING);
         rf.initReceive();
         ESP_LOGI("custom", "Enabled ITHO again");

--- a/itho.yaml
+++ b/itho.yaml
@@ -101,6 +101,22 @@ switch:
   switches:
     name: "FanSendJoin"
 
+- platform: template
+  name: "Disable ITHO, allow OTA"
+  lambda: |-
+    return EnableItho;
+  turn_on_action:
+    - lambda: |-
+        EnableItho = true;
+        detachInterrupt(D1);
+        ESP_LOGI("custom", "Disabled ITHO, to allow OTA (otherwise 'Ticker' library will fail OTA)");
+  turn_off_action:
+    - lambda: |-
+        EnableItho = true;
+        attachInterrupt(D1, ITHOinterrupt, RISING);
+        rf.initReceive();
+        ESP_LOGI("custom", "Enabled ITHO again");
+
 text_sensor:
 - platform: custom
   lambda: |-


### PR DESCRIPTION
The original code does not allow OTA (it stops because of the ticker library), the PR contains a new switch to (temporary) disables the ITHO signals to be handled by the code. It can be enabled again.