### PR TITLE
Add fan entity

### DIFF
--- a/itho.yaml
+++ b/itho.yaml
@@ -59,6 +59,7 @@ switch:
 
   switches:
     name: "FanSendMedium"
+    id: swfan_medium
 
 - platform: custom
   lambda: |-
@@ -68,6 +69,7 @@ switch:
 
   switches:
     name: "FanSendHigh"
+    id: swfan_high
 
 - platform: custom
   lambda: |-
@@ -117,7 +119,31 @@ text_sensor:
       icon: "mdi:timer"  
     - name: "lastid"
 
-  
-      
+fan:
+  - platform: speed
+    output: outputswitch
+    name: "ITHO Fan"
+    speed_count: 2
+    
 
- 
+
+output:
+  - platform: template
+    id: outputswitch
+    type: float
+    write_action:
+      - if:
+          condition:
+            lambda: return ((state == 0) );
+          then:
+            - switch.turn_on: swfan_low
+      - if:
+          condition:
+            lambda: return ((state == 0.50) );
+          then:
+            - switch.turn_on: swfan_medium
+      - if:
+          condition:
+            lambda: return ((state == 1) );
+          then:
+            - switch.turn_on: swfan_high 


### PR DESCRIPTION
this update creates a fan entity in Home Assistant. It converts the percentage (received from HA) into a switch. The fan has two speeds, besides low. Low = 0%, Medium = 50% and High = 100%. I am not sure how to set to Full speed.