### PR TITLE
Fix some compile warnings

### DIFF
--- a/itho.h
+++ b/itho.h
@@ -4,7 +4,7 @@
 
 //List of States:
 
-// 0 - Itho ventilation Standby
+// 0 - Itho ventilation unit to standby speed
 // 1 - Itho ventilation unit to lowest speed
 // 2 - Itho ventilation unit to medium speed
 // 3 - Itho ventilation unit to high speed
@@ -53,7 +53,7 @@ String TextSensorfromState(int currentState)
 	switch (currentState)
 	{
 	case 0: 
-		return "Standby";
+		return "Off";
 		break;
 	case 1: 
 		return "Low";
@@ -139,6 +139,7 @@ class FanRecv : public PollingComponent {
 // send: low, medium, high, full
 //       timer 1 (10 minutes), 2 (20), 3 (30)
 // To optimize testing, reset published state immediately so you can retrigger (i.e. momentarily button press)
+
 
 class FanSendStandby : public Component, public Switch {
 public:

--- a/itho.h
+++ b/itho.h
@@ -17,8 +17,8 @@ typedef struct { String Id; String Roomname; } IdDict;
 
 // Global struct to store Names, should be changed in boot call,to set user specific
 IdDict Idlist[] = { {"ID1", "Controller Room1"},
-					{"ID2",	"Controller Room2"},
-					{"ID3",	"Controller Room3"}
+		    {"ID2", "Controller Room2"},
+		    {"ID3", "Controller Room3"}
 				};
 IthoCC1101 rf;
 void ITHOinterrupt() IRAM_ATTR;

--- a/itho.yaml
+++ b/itho.yaml
@@ -46,14 +46,21 @@ ota:
           ESP_LOGI("custom", "Disable Interrupts, to allow OTA without intterupts");
           detachInterrupt(D1);
           delay(500);
-
 switch:
+- platform: custom
+  lambda: |-
+    auto fansendstandby = new FanSendStandby();
+    App.register_component(fansendstandby);
+    return {fansendstandby};
+  switches:
+    name: "FanSendStandby"
+    id: swfan_standby
+
 - platform: custom
   lambda: |-
     auto fansendlow = new FanSendLow();
     App.register_component(fansendlow);
     return {fansendlow};
-
   switches:
     name: "FanSendLow"
     id: swfan_low
@@ -63,45 +70,45 @@ switch:
     auto fansendmedium = new FanSendMedium();
     App.register_component(fansendmedium);
     return {fansendmedium};
-
   switches:
     name: "FanSendMedium"
+    id: swfan_medium
 
 - platform: custom
   lambda: |-
     auto fansendhigh = new FanSendHigh();
     App.register_component(fansendhigh);
     return {fansendhigh};
-
   switches:
     name: "FanSendHigh"
+    id: swfan_high
 
 - platform: custom
   lambda: |-
     auto fansendt1 = new FanSendIthoTimer1();
     App.register_component(fansendt1);
     return {fansendt1};
-
   switches:
     name: "FanSendTimer1"
+    id: swfan_timer1
 
 - platform: custom
   lambda: |-
     auto fansendt2 = new FanSendIthoTimer2();
     App.register_component(fansendt2);
     return {fansendt2};
-
   switches:
     name: "FanSendTimer2"
+    id: swfan_timer2
 
 - platform: custom
   lambda: |-
     auto fansendt3 = new FanSendIthoTimer3();
     App.register_component(fansendt3);
     return {fansendt3};
-
   switches:
     name: "FanSendTimer3"
+    id: swfan_timer3
 
 - platform: custom
   lambda: |-
@@ -110,6 +117,7 @@ switch:
     return {fansendjoin};
   switches:
     name: "FanSendJoin"
+    id: swfan_join
 
 text_sensor:
 - platform: custom
@@ -123,7 +131,6 @@ text_sensor:
     - name: "fantimer"
       icon: "mdi:timer"  
     - name: "lastid"
-
   
       
 


### PR DESCRIPTION
Hey,

During compile, I got 2 types of warnings:
- deprecated function ICACHE_RAM_ATTR; to be replaced by IRAM_ATTR
- missing DucoStandby and IthoStandby calls.

Warnings are gone.
The standby switch is now visible, but not working. It sets the box to "low" instead of switching it off entirely. I remember the ESPEasy version (from arjenhiemstra) I used in the past actually did switch the box off. Also, if I use the leave home button on my remote, it is switching of completely, but nothing shows in the esphome log

I will do some more testing to see if I can figure out what is missing :)



